### PR TITLE
Sanitize OpenAPI parameter names with invalid characters

### DIFF
--- a/packages/openapi-mcp-server/src/server.ts
+++ b/packages/openapi-mcp-server/src/server.ts
@@ -124,7 +124,14 @@ export default class OpenAPIMCPServer {
    */
   // eslint-disable-next-line class-methods-use-this
   protected callToolBody(tool: Tool, api: API, body: Record<string, unknown>) {
-    return body;
+    if (!api.parameterNameMapping) {
+      return body;
+    }
+    const mapped: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(body)) {
+      mapped[api.parameterNameMapping[key] ?? key] = value;
+    }
+    return mapped;
   }
 
   /**

--- a/packages/openapi-mcp-server/src/types.ts
+++ b/packages/openapi-mcp-server/src/types.ts
@@ -8,4 +8,5 @@ export type API = {
   method: HttpMethod;
   path: string;
   contentType: ContentType;
+  parameterNameMapping?: Record<string, string>; // sanitized → original
 };

--- a/packages/openapi-mcp-server/src/utils/loadTools.ts
+++ b/packages/openapi-mcp-server/src/utils/loadTools.ts
@@ -40,6 +40,20 @@ const trimSlashes = (str: string) => {
   return str.replace(/^\/+|\/+$/g, '');
 };
 
+// Anthropic API requires property names to match ^[a-zA-Z0-9_.-]{1,64}$
+const VALID_PROPERTY_KEY_PATTERN = /^[a-zA-Z0-9_.-]{1,64}$/;
+
+export function sanitizePropertyKey(name: string): string {
+  if (VALID_PROPERTY_KEY_PATTERN.test(name)) {
+    return name;
+  }
+  return name
+    .replace(/</g, '_before')
+    .replace(/>/g, '_after')
+    .replace(/[^a-zA-Z0-9_.-]/g, '_')
+    .slice(0, 64);
+}
+
 function toSchema(
   schema: OpenAPIV3.SchemaObject,
   description?: string,
@@ -144,14 +158,22 @@ export default function loadTools(specs: OpenAPISpec[], filters?: ToolFilters) {
                 .filter((param) => 'name' in param && 'in' in param)
                 .forEach((param) => {
                   const schema = param.schema as OpenAPIV3.SchemaObject;
+                  const sanitized = sanitizePropertyKey(param.name);
 
-                  tool.inputSchema.properties[param.name] = toSchema(
+                  tool.inputSchema.properties[sanitized] = toSchema(
                     schema,
                     param.description || `${param.name} parameter`,
                   );
 
+                  if (sanitized !== param.name) {
+                    if (!api.parameterNameMapping) {
+                      api.parameterNameMapping = {};
+                    }
+                    api.parameterNameMapping[sanitized] = param.name;
+                  }
+
                   if (param.required) {
-                    tool.inputSchema.required.push(param.name);
+                    tool.inputSchema.required.push(sanitized);
                   }
                 });
             }
@@ -169,18 +191,29 @@ export default function loadTools(specs: OpenAPISpec[], filters?: ToolFilters) {
             if (content?.schema) {
               const schema = content.schema as OpenAPIV3.SchemaObject;
 
-              if (schema.required) {
-                tool.inputSchema.required.push(...schema.required);
-              }
-
               if (schema.properties) {
                 Object.entries(schema.properties).forEach(([key, value]) => {
                   const property = value as OpenAPIV3.SchemaObject;
-                  tool.inputSchema.properties[key] = toSchema(
+                  const sanitized = sanitizePropertyKey(key);
+
+                  tool.inputSchema.properties[sanitized] = toSchema(
                     property,
                     property.description ?? `${key} parameter`,
                   );
+
+                  if (sanitized !== key) {
+                    if (!api.parameterNameMapping) {
+                      api.parameterNameMapping = {};
+                    }
+                    api.parameterNameMapping[sanitized] = key;
+                  }
                 });
+              }
+
+              if (schema.required) {
+                tool.inputSchema.required.push(
+                  ...schema.required.map((r) => sanitizePropertyKey(r)),
+                );
               }
             }
 

--- a/packages/openapi-mcp-server/tests/server.spec.ts
+++ b/packages/openapi-mcp-server/tests/server.spec.ts
@@ -516,4 +516,73 @@ describe('OpenAPIMCPServer', () => {
       customServer.testEnsureCapability('prompts');
     }).toThrow('prompts not supported');
   });
+
+  it('should reverse-map sanitized parameter names in callToolBody', () => {
+    class TestServer extends OpenAPIMCPServer {
+      public testCallToolBody(
+        tool: Tool,
+        api: API,
+        body: Record<string, unknown>,
+      ) {
+        return this.callToolBody(tool, api, body);
+      }
+    }
+
+    const testServer = new TestServer(mockConfig);
+
+    const apiWithMapping: API = {
+      path: '/api/calls',
+      method: 'GET',
+      contentType: 'application/json',
+      parameterNameMapping: {
+        DateCreated_before: 'DateCreated<',
+        StartTime_after: 'StartTime>',
+      },
+    };
+
+    const result = testServer.testCallToolBody(
+      mockTool,
+      apiWithMapping,
+      {
+        DateCreated_before: '2024-01-01',
+        StartTime_after: '2024-06-01',
+        Status: 'completed',
+      },
+    );
+
+    expect(result).toEqual({
+      'DateCreated<': '2024-01-01',
+      'StartTime>': '2024-06-01',
+      Status: 'completed',
+    });
+  });
+
+  it('should pass body through unchanged when no parameterNameMapping exists', () => {
+    class TestServer extends OpenAPIMCPServer {
+      public testCallToolBody(
+        tool: Tool,
+        api: API,
+        body: Record<string, unknown>,
+      ) {
+        return this.callToolBody(tool, api, body);
+      }
+    }
+
+    const testServer = new TestServer(mockConfig);
+
+    const apiWithoutMapping: API = {
+      path: '/api/resource',
+      method: 'GET',
+      contentType: 'application/json',
+    };
+
+    const body = { param1: 'value1', param2: 'value2' };
+    const result = testServer.testCallToolBody(
+      mockTool,
+      apiWithoutMapping,
+      body,
+    );
+
+    expect(result).toBe(body);
+  });
 });

--- a/packages/openapi-mcp-server/tests/utils/loadTools.spec.ts
+++ b/packages/openapi-mcp-server/tests/utils/loadTools.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { HttpMethod } from '@app/types';
 import { OpenAPISpec } from '@app/utils';
-import loadTools from '@app/utils/loadTools';
+import loadTools, { sanitizePropertyKey } from '@app/utils/loadTools';
 
 describe('loadTools', () => {
   const createMockSpec = (
@@ -962,5 +962,118 @@ describe('loadTools', () => {
 
     // Check required fields
     expect(postTool.inputSchema.required).toContain('items');
+  });
+
+  it('should sanitize parameter names with invalid characters', () => {
+    const specs: OpenAPISpec[] = [
+      createMockSpec('service1', {
+        '/calls': {
+          get: {
+            operationId: 'listCalls',
+            description: 'List calls',
+            parameters: [
+              {
+                name: 'DateCreated<',
+                in: 'query',
+                required: false,
+                description: 'Before date',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'StartTime>',
+                in: 'query',
+                required: true,
+                description: 'After start time',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'Status',
+                in: 'query',
+                required: false,
+                description: 'Call status',
+                schema: { type: 'string' },
+              },
+            ],
+          },
+        },
+      }),
+    ];
+
+    const { tools, apis } = loadTools(specs);
+    const tool = tools.get('service1--listCalls')!;
+    const api = apis.get('service1--listCalls')!;
+
+    // Sanitized keys should be used in the schema
+    expect(tool.inputSchema.properties).toHaveProperty('DateCreated_before');
+    expect(tool.inputSchema.properties).toHaveProperty('StartTime_after');
+    expect(tool.inputSchema.properties).toHaveProperty('Status');
+
+    // Original invalid keys should not be present
+    expect(tool.inputSchema.properties).not.toHaveProperty('DateCreated<');
+    expect(tool.inputSchema.properties).not.toHaveProperty('StartTime>');
+
+    // Required array should use sanitized names
+    expect(tool.inputSchema.required).toContain('StartTime_after');
+    expect(tool.inputSchema.required).not.toContain('StartTime>');
+
+    // Mapping should be recorded on the API
+    expect(api.parameterNameMapping).toEqual({
+      DateCreated_before: 'DateCreated<',
+      StartTime_after: 'StartTime>',
+    });
+  });
+
+  it('should sanitize request body property names with invalid characters', () => {
+    const specs: OpenAPISpec[] = [
+      createMockSpec('service1', {
+        '/records': {
+          post: {
+            operationId: 'createRecord',
+            description: 'Create record',
+            requestBody: {
+              content: {
+                'application/x-www-form-urlencoded': {
+                  schema: {
+                    type: 'object',
+                    required: ['DateCreated<'],
+                    properties: {
+                      'DateCreated<': {
+                        type: 'string',
+                        description: 'Before date',
+                      },
+                      Name: {
+                        type: 'string',
+                        description: 'Record name',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    ];
+
+    const { tools, apis } = loadTools(specs);
+    const tool = tools.get('service1--createRecord')!;
+    const api = apis.get('service1--createRecord')!;
+
+    expect(tool.inputSchema.properties).toHaveProperty('DateCreated_before');
+    expect(tool.inputSchema.properties).not.toHaveProperty('DateCreated<');
+    expect(tool.inputSchema.required).toContain('DateCreated_before');
+    expect(api.parameterNameMapping).toEqual({
+      DateCreated_before: 'DateCreated<',
+    });
+  });
+
+  it('sanitizePropertyKey should leave valid names unchanged', () => {
+    expect(sanitizePropertyKey('Status')).toBe('Status');
+    expect(sanitizePropertyKey('my.param-name_1')).toBe('my.param-name_1');
+  });
+
+  it('sanitizePropertyKey should replace < and > correctly', () => {
+    expect(sanitizePropertyKey('DateCreated<')).toBe('DateCreated_before');
+    expect(sanitizePropertyKey('StartTime>')).toBe('StartTime_after');
   });
 });


### PR DESCRIPTION
## Summary
- Twilio's OpenAPI specs use `<` and `>` in parameter names (e.g., `DateCreated<`, `StartTime>`) for date range filters, which violate the Anthropic API pattern `^[a-zA-Z0-9_.-]{1,64}$` and cause a 400 error on tool registration
- Sanitizes invalid property keys in `loadTools` (`<` → `_before`, `>` → `_after`, other invalid chars → `_`) and stores a reverse mapping on the `API` object so keys are restored to their original names before making Twilio API calls
- Adds 6 new tests covering sanitization logic and reverse mapping in `callToolBody`

Fixes #42

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — all 127 tests pass (81 in openapi-mcp-server, 46 in mcp)
- [ ] Manual: run the MCP server against Twilio specs and verify the 9 affected tools no longer have `<`/`>` in their property keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)