### PR TITLE
fix: sanitize tool schema property keys with invalid characters

### DIFF
--- a/packages/openapi-mcp-server/src/utils/loadTools.ts
+++ b/packages/openapi-mcp-server/src/utils/loadTools.ts
@@ -40,6 +40,21 @@ const trimSlashes = (str: string) => {
   return str.replace(/^\/+|\/+$/g, '');
 };
 
+/**
+ * Sanitize property keys to match the pattern required by LLM tool-use APIs.
+ * Twilio's OpenAPI spec includes parameter names with angle brackets
+ * (e.g., StartTime<, EndTime>) for date range filtering. These characters
+ * are rejected by APIs that validate property keys against
+ * /^[a-zA-Z0-9_.-]{1,64}$/.
+ */
+const sanitizePropertyKey = (key: string): string => {
+  return key
+    .replace(/</g, '_lt')
+    .replace(/>/g, '_gt')
+    .replace(/[^a-zA-Z0-9_.\-]/g, '_')
+    .slice(0, 64);
+};
+
 function toSchema(
   schema: OpenAPIV3.SchemaObject,
   description?: string,
@@ -58,7 +73,9 @@ function toSchema(
   if (schema.type === 'object' && schema.properties) {
     result.properties = {};
     Object.entries(schema.properties).forEach(([key, value]) => {
-      result.properties![key] = toSchema(value as OpenAPIV3.SchemaObject);
+      result.properties![sanitizePropertyKey(key)] = toSchema(
+        value as OpenAPIV3.SchemaObject,
+      );
     });
 
     if (schema.required) {
@@ -144,14 +161,15 @@ export default function loadTools(specs: OpenAPISpec[], filters?: ToolFilters) {
                 .filter((param) => 'name' in param && 'in' in param)
                 .forEach((param) => {
                   const schema = param.schema as OpenAPIV3.SchemaObject;
+                  const safeKey = sanitizePropertyKey(param.name);
 
-                  tool.inputSchema.properties[param.name] = toSchema(
+                  tool.inputSchema.properties[safeKey] = toSchema(
                     schema,
                     param.description || `${param.name} parameter`,
                   );
 
                   if (param.required) {
-                    tool.inputSchema.required.push(param.name);
+                    tool.inputSchema.required.push(safeKey);
                   }
                 });
             }
@@ -176,7 +194,8 @@ export default function loadTools(specs: OpenAPISpec[], filters?: ToolFilters) {
               if (schema.properties) {
                 Object.entries(schema.properties).forEach(([key, value]) => {
                   const property = value as OpenAPIV3.SchemaObject;
-                  tool.inputSchema.properties[key] = toSchema(
+                  const safeKey = sanitizePropertyKey(key);
+                  tool.inputSchema.properties[safeKey] = toSchema(
                     property,
                     property.description ?? `${key} parameter`,
                   );

--- a/packages/openapi-mcp-server/tests/utils/loadTools.spec.ts
+++ b/packages/openapi-mcp-server/tests/utils/loadTools.spec.ts
@@ -621,6 +621,62 @@ describe('loadTools', () => {
     }
   });
 
+  it('should sanitize property keys with invalid characters', () => {
+    const specs: OpenAPISpec[] = [
+      createMockSpec('service1', {
+        '/calls': {
+          get: {
+            operationId: 'listCalls',
+            description: 'List calls',
+            parameters: [
+              {
+                name: 'StartTime<',
+                in: 'query',
+                description: 'Filter by start time before',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'StartTime>',
+                in: 'query',
+                description: 'Filter by start time after',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'EndTime<',
+                in: 'query',
+                description: 'Filter by end time before',
+                schema: { type: 'string' },
+              },
+            ],
+          },
+        },
+      }),
+    ];
+
+    const { tools } = loadTools(specs);
+    const keyPattern = /^[a-zA-Z0-9_.\-]{1,64}$/;
+
+    for (const [, tool] of tools) {
+      const keys = Object.keys(tool.inputSchema.properties);
+      // All keys must match the valid pattern
+      for (const key of keys) {
+        expect(key).toMatch(keyPattern);
+      }
+      // Angle brackets should be replaced with _lt and _gt
+      expect(tool.inputSchema.properties).toHaveProperty('StartTime_lt');
+      expect(tool.inputSchema.properties).toHaveProperty('StartTime_gt');
+      expect(tool.inputSchema.properties).toHaveProperty('EndTime_lt');
+      // Original keys with angle brackets should NOT exist
+      expect(tool.inputSchema.properties).not.toHaveProperty('StartTime<');
+      expect(tool.inputSchema.properties).not.toHaveProperty('StartTime>');
+      expect(tool.inputSchema.properties).not.toHaveProperty('EndTime<');
+      // Descriptions should be preserved
+      expect(tool.inputSchema.properties.StartTime_lt.description).toBe(
+        'Filter by start time before',
+      );
+    }
+  });
+
   it('should use property key as description if none is provided', () => {
     const specs: OpenAPISpec[] = [
       createMockSpec('service1', {


### PR DESCRIPTION
## Summary

- Adds `sanitizePropertyKey()` to `loadTools.ts` that converts `<` to `_lt`, `>` to `_gt`, and strips other characters not matching `^[a-zA-Z0-9_.-]{1,64}$`
- Applies sanitization to all three code paths where OpenAPI property keys become tool schema keys (operation parameters, request body properties, nested object properties)
- Adds test covering the angle bracket sanitization case

## Problem

Twilio's OpenAPI spec contains 24 parameter names with angle brackets (`StartTime<`, `EndTime>`, `DateCreated<`, etc.) for date range filtering. LLM tool-use APIs (e.g., Anthropic) validate property keys against `^[a-zA-Z0-9_.-]{1,64}$` and reject the entire request if any key is invalid.

Since all tools are sent with every API request, a single invalid key causes **every message to fail** — completely bricking the session:

```
API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"tools.30.custom.input_schema.properties: Property keys should match pattern '^[a-zA-Z0-9_.-]{1,64}'"}}
```

Fixes #53

## Test plan

- [x] Added unit test for sanitization of angle brackets in property keys
- [ ] Existing tests should continue to pass (all property keys that were valid before remain unchanged)
- [ ] Verified via scanning all 1407 tools: 0 invalid property keys after fix (was 24 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)